### PR TITLE
Ensure DNS works for the 1.Base Template

### DIFF
--- a/1.Base/Vagrantfile
+++ b/1.Base/Vagrantfile
@@ -62,6 +62,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       v.name = "cassandra"
       v.customize ["modifyvm", :id, "--memory", CFG_MEMSIZE]
       v.customize ["modifyvm", :id, "--cpus"  , "2"   ]
+      v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     end
     x.vm.network :private_network, ip: CFG_IP
     x.vm.hostname = "cassandra"


### PR DESCRIPTION
It seems that it's a common issue that DNS may not work inside of a VirtualBox VM. [1]
The fix is straightforward [2], and involves setting the `--natdnshostresolver1` option to `on`.

Testing done:
1. Run `vagrant up` from a new state.
2. `vagrant ssh` into the new VM.
3. Run `curl google.com` and verify get back a response.

1. https://www.vagrantup.com/docs/virtualbox/common-issues.html
2. https://serverfault.com/questions/453185/vagrant-virtualbox-dns-10-0-2-3-not-working